### PR TITLE
Fix typo in Lambda module comment

### DIFF
--- a/infrastructure/modules/lambda/main.tf
+++ b/infrastructure/modules/lambda/main.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_alias" "lambda_alias" {
   function_name    = aws_lambda_function.lambda_function.function_name
   function_version = aws_lambda_function.lambda_function.version
   # Create the alias but don't update it when the version changes
-  # We will manage updating the alias via a separeate deployment
+  # We will manage updating the alias via a separate deployment
   # pipeline
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Summary
- fix a small typo in the lambda module's comments

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687b8869229c8320af4cabcc9a543a53