### PR TITLE
Fix newline trimming for public key

### DIFF
--- a/infrastructure/modules/keys/main.tf
+++ b/infrastructure/modules/keys/main.tf
@@ -39,7 +39,7 @@ resource "aws_secretsmanager_secret_version" "keys" {
 }
 
 locals {
-  public_key_pem_trimmed = regex("^\\-+BEGIN PUBLIC KEY\\-+(.*?)\\-+END PUBLIC KEY\\-+$", replace(tls_private_key.key.public_key_pem, "/\\n/", ""))[0]
+  public_key_pem_trimmed = regex("^\\-+BEGIN PUBLIC KEY\\-+(.*?)\\-+END PUBLIC KEY\\-+$", replace(tls_private_key.key.public_key_pem, "\n", ""))[0]
 }
 
 data "external" "jwks" {


### PR DESCRIPTION
## Summary
- update replacement logic to strip newline characters in `keys` module

## Testing
- `pre-commit run --files infrastructure/modules/keys/main.tf` *(fails: go-mod-tidy modified unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687b887400c0832099c3b72ac58120a1